### PR TITLE
Fix for UnicodeDecodeError when building under Docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,7 +261,7 @@ see `tests/nonci/test_albert.py <https://github.com/kpe/bert-for-tf2/blob/master
 
   vocab_file = os.path.join(model_dir, "vocab.txt")
   tokenizer = bert.albert_tokenization.FullTokenizer(vocab_file=vocab_file)
-  tokens = tokenizer.tokenize("你好世界")
+  tokens = tokenizer.tokenize(u"你好世界")
   token_ids = tokenizer.convert_tokens_to_ids(tokens)
 
 Resources

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def _version():
 __version__ = _version()
 
 
-with open("README.rst", "r") as fh:
+with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r") as reader:


### PR DESCRIPTION
When building this library using Docker, it crashes with the following error:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 9351: ordinal not in range(128)

This happens because of the Chinese characters in the README.rst file. This pull request fixes that by explicitly defining the characters as Unicode and reading the file with utf-8 encoding.
