### PR TITLE
Implement Pooler layer in BertModelLayer

### DIFF
--- a/bert/loader.py
+++ b/bert/loader.py
@@ -55,7 +55,7 @@ def map_from_stock_variale_name(name, prefix="bert"):
     name = "/".join(pns + ns[1:])
     ns = name.split("/")
 
-    if ns[1] not in ["encoder", "embeddings"]:
+    if ns[1] not in ["encoder", "embeddings", "pooler"]:
         return None
     if ns[1] == "embeddings":
         if ns[2] == "LayerNorm":
@@ -67,6 +67,8 @@ def map_from_stock_variale_name(name, prefix="bert"):
             return "/".join(ns[:4] + ns[5:])
         else:
             return name
+    if ns[1] == "pooler":
+        return "/".join(ns)
     return None
 
 
@@ -81,7 +83,7 @@ def map_to_stock_variable_name(name, prefix="bert"):
     name = "/".join(["bert"] + ns[len(pns):])
     ns   = name.split("/")
 
-    if ns[1] not in ["encoder", "embeddings"]:
+    if ns[1] not in ["encoder", "embeddings", "pooler"]:
         return None
     if ns[1] == "embeddings":
         if ns[2] == "LayerNorm":
@@ -99,6 +101,8 @@ def map_to_stock_variable_name(name, prefix="bert"):
             return "/".join(ns[:4] + ["dense"] + ns[4:])
         else:
             return name
+    if ns[1] == "pooler":
+        return "/".join(ns)
     return None
 
 
@@ -181,7 +185,7 @@ def _checkpoint_exists(ckpt_path):
 
 
 def bert_prefix(bert: BertModelLayer):
-    re_bert = re.compile(r'(.*)/(embeddings|encoder)/(.+):0')
+    re_bert = re.compile(r'(.*)/(embeddings|encoder|pooler)/(.+):0')
     match = re_bert.match(bert.weights[0].name)
     assert match, "Unexpected bert layer: {} weight:{}".format(bert, bert.weights[0].name)
     prefix = match.group(1)

--- a/bert/loader_albert.py
+++ b/bert/loader_albert.py
@@ -244,7 +244,7 @@ def map_to_tfhub_albert_variable_name(name, prefix="bert"):
     name = "/".join(["bert"] + ns[len(pns):])
     ns   = name.split("/")
 
-    if ns[1] not in ["encoder", "embeddings"]:
+    if ns[1] not in ["encoder", "embeddings", "pooler"]:
         return None
     if ns[1] == "embeddings":
         if ns[2] == "LayerNorm":
@@ -256,6 +256,8 @@ def map_to_tfhub_albert_variable_name(name, prefix="bert"):
             return "/".join(ns[:4] + ["dense"] + ns[4:])
         else:
             return name
+    if ns[1] == "pooler":
+        return "/".join(ns)
     return None
 
 

--- a/bert/pooler.py
+++ b/bert/pooler.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+#
+# created by mrinaald on 17.Oct.2020 at 12:33
+#
+
+from __future__ import absolute_import, division, print_function
+
+import tensorflow as tf
+import params_flow as pf
+
+from bert.layer import Layer
+
+
+class BertPoolerLayer(Layer):
+    class Params(Layer.Params):
+        hidden_size = 768
+
+    def _construct(self, **kwargs):
+        super()._construct(**kwargs)
+        self.pooler_layer = None
+
+    def build(self, input_shape):
+        # Input Shape: (BATCH_SIZE, SEQUENCE_LENGTH, HIDDEN_SIZE)
+        assert len(input_shape) == 3
+
+        self.input_spec = tf.keras.layers.InputSpec(shape=input_shape)
+        self.pooler_layer = tf.keras.layers.Dense(units=self.params.hidden_size,
+                                                  activation='tanh',
+                                                  kernel_initializer=self.create_initializer(),
+                                                  name="dense")
+
+        super(BertPoolerLayer, self).build(input_shape)
+
+    def call(self, inputs, mask=None, training=None):
+        first_token_tensor = inputs[:, 0, :]
+
+        pooled_output = self.pooler_layer(first_token_tensor)
+        return pooled_output


### PR DESCRIPTION
Implement the Pooler layer from the BERT model architecture, which creates a pooled feature vector using the first token from the output sequence. In many of the online blogs and examples, they mention to take the pooled output from BERT directly and add dense layers (or other layers) on this pooled output.

With this change, the pooler layer weights available in the downloaded checkpoint files of various models can also be loaded into the BertModelLayer object.

- Original Behaviour:
Done loading 37 BERT weights from: ~/Downloads/BERT/BERT-Weights/uncased_L-2_H-128_A-2/bert_model.ckpt into <bert.model.BertModelLayer object at 0x7f6a9c64df40> (prefix:bert_orig). Count of weights not found in the checkpoint was: [0]. Count of weights with mismatched shape: [0]
Unused weights from checkpoint: 
	bert/pooler/dense/bias
	bert/pooler/dense/kernel
	cls/predictions/output_bias
	cls/predictions/transform/LayerNorm/beta
	cls/predictions/transform/LayerNorm/gamma
	cls/predictions/transform/dense/bias
	cls/predictions/transform/dense/kernel
	cls/seq_relationship/output_bias
	cls/seq_relationship/output_weights

- Modified Behaviour:
Done loading 39 BERT weights from: ~/Downloads/BERT/BERT-Weights/uncased_L-2_H-128_A-2/bert_model.ckpt into <bert.model.BertModelLayer object at 0x7f6a9d026a30> (prefix:bert_pooled). Count of weights not found in the checkpoint was: [0]. Count of weights with mismatched shape: [0]
Unused weights from checkpoint: 
	cls/predictions/output_bias
	cls/predictions/transform/LayerNorm/beta
	cls/predictions/transform/LayerNorm/gamma
	cls/predictions/transform/dense/bias
	cls/predictions/transform/dense/kernel
	cls/seq_relationship/output_bias
	cls/seq_relationship/output_weights

To get the pooler layer output, we need to initialize the BertModelLayer as follows:
`l_bert = bert.BertModelLayer.from_params(bert_params, return_pooler_output=True, name="bert")`