### PR TITLE
Fix for #91 for newer versions of tensorflow

### DIFF
--- a/bert/attention.py
+++ b/bert/attention.py
@@ -6,8 +6,8 @@
 from __future__ import absolute_import, division, print_function
 
 import tensorflow as tf
-from tensorflow.python import keras
-from tensorflow.python.keras import backend as K
+from tensorflow import keras
+from tensorflow.keras import backend as K
 
 from bert.layer import Layer
 

--- a/bert/transformer.py
+++ b/bert/transformer.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import tensorflow as tf
-from tensorflow.python import keras
+from tensorflow import keras
 
 from params_flow import LayerNormalization
 


### PR DESCRIPTION
Replaced "from tensorflow.python import keras" with "from tensorflow import keras". 